### PR TITLE
Added functional version of pipe which does not need |> operator

### DIFF
--- a/src/Pipe.jl
+++ b/src/Pipe.jl
@@ -20,7 +20,7 @@ function rewrite(ff::Expr,target)
         rep.args = map(replace,rep.args)
         rep
     end
-       
+
     if (ff.head==:call)
         rep_args = map(replace,ff.args)
         if ff.args != rep_args
@@ -33,14 +33,14 @@ function rewrite(ff::Expr,target)
     #Apply to a function that is being returned by ff, (ff could be a function call or something more complex)
     rewrite_apply(ff,target)
 end
-        
+
 
 function rewrite_apply(ff::@compat(Union{Symbol,Expr}), target)
     #function application
     :($ff($target))
 end
 
-function rewrite(ff::Symbol,target) 
+function rewrite(ff::Symbol,target)
     rewrite_apply(ff,target)
 end
 
@@ -53,7 +53,7 @@ function funnel(ee::Expr)
     if (ee.args[1]==:|>)
         ff = ee.args[3]
         target = funnel(ee.args[2]) #Recurse
-        
+
         rewrite(ff,target)
     else
         #Not in a piping situtation
@@ -65,6 +65,12 @@ macro pipe(ee)
     esc(funnel(ee))
 end
 
-
+macro pipe(ee...)
+  target = ee[1]
+  for ff in ee[2:end]
+    target = rewrite(ff, target)
+  end
+  target
+end
 
 end


### PR DESCRIPTION
Dear package author,

thank you very much for this awesome and simple package. I use quite often.

Coming from python knowing the pipe function http://toolz.readthedocs.io/en/latest/api.html#toolz.functoolz.pipe
I just implemented a functional version of the ``@pipe`` macro using the existing functionalities (it is actually only a fold/reduce using `rewrite` operator).

```julia
julia> @pipe(
  1:100,
  map(x->x*x, _),
  filter(x->x<10, _)
)
3-element Array{Int64,1}:
 1
 4
 9
```
This style mimics python's ``toolz.pipe``. In general I find it to be very well readable for long pipelines. Compare the current multiline alternative
```julia
julia> @pipe  1:100 |>
  map(x->x*x, _) |>
  filter(x->x<10, _)
```


Note that this also adds a very condensed style too (as Julia's macros can be called with parantheses or without) (I added further spaces to show that Julia's expression matching is astonishingly stable)
```julia
julia> @pipe   1    _ + 2       9 / _
3.0
```

Please, what do you think about this?
best,
Stephan
