### PR TITLE
Remove 0.7 deprecations from tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ julia:
   - 0.4
   - 0.5
   - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.3
-  - 0.4
-  - 0.5
-  - 0.6
   - 0.7
   - 1.0
   - nightly

--- a/README.md
+++ b/README.md
@@ -4,15 +4,10 @@
  - Julia 0.4: [![Build Status 0.4](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/2)](https://travis-ci.org/oxinabox/Pipe.jl)
  - Julia 0.5: [![Build Status 0.5](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/3)](https://travis-ci.org/oxinabox/Pipe.jl)
  - Julia 0.6: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/4)](https://travis-ci.org/oxinabox/Pipe.jl)
- - Julia Nightly: [![Build Status Nightly](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/5)](https://travis-ci.org/oxinabox/Pipe.jl)
+ - Julia 0.7: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/5)](https://travis-ci.org/oxinabox/Pipe.jl)
+ - Julia 1.0: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/6)](https://travis-ci.org/oxinabox/Pipe.jl)
+- Julia Nightly: [![Build Status Nightly](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/7)](https://travis-ci.org/oxinabox/Pipe.jl)
  
-## Installation
-As per normal install by calling (On the julia REPL or IJulia):
-
-```
-Pkg.add("Pipe")
-```
-
 
 ## Usage
 
@@ -25,15 +20,15 @@ except if you place a underscore in the right hand of the expressing, it will be
 So:
 
 ```
-@pipe a|>b(x,_) # == b(x,a) #Not: (b(x,_))(a) 
+@pipe a |> b(x,_) # == b(x,a) #Not: (b(x,_))(a) 
 ```
 
 Futher  the _ can be unpacked, called, deindexed offetc.
 
 ```
-@pipe a|>b(_...) # == b(a...)
-@pipe a|>b(_(1,2)) # == b(a(1,2))
-@pipe a|>b(_[3]) # == b(a[3])
+@pipe a |> b(_...) # == b(a...)
+@pipe a |> b(_(1,2)) # == b(a(1,2))
+@pipe a |> b(_[3]) # == b(a[3])
 ```
 
 This last can be used for interacting with multiple returned values. In general however, this is frowned upon.
@@ -72,15 +67,7 @@ end
 @pipe 10 |> ratio(_,4,1) |> percent(_...) # = 400.0, outputs splitting on ratio 4:1 Once
 ```
 
-
-
-
 ---------------------
-
-## Issues
-
-If you are using `_` as a variable name etc, you will not be able to use that variable inside this  (except as most LHS, but that will get confusing). If you have a convincing reason why you should be using _ as a variable name then do tell me.
-I'm not 100% sold that _ is the best marker for this.
 
 ## See Also:
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,7 @@
 # Pipe
 
-- Julia 0.3: [![Build Status 0.3](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/1)](https://travis-ci.org/oxinabox/Pipe.jl)
- - Julia 0.4: [![Build Status 0.4](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/2)](https://travis-ci.org/oxinabox/Pipe.jl)
- - Julia 0.5: [![Build Status 0.5](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/3)](https://travis-ci.org/oxinabox/Pipe.jl)
- - Julia 0.6: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/4)](https://travis-ci.org/oxinabox/Pipe.jl)
- - Julia 0.7: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/5)](https://travis-ci.org/oxinabox/Pipe.jl)
- - Julia 1.0: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/6)](https://travis-ci.org/oxinabox/Pipe.jl)
+ - Julia 0.7: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/1)](https://travis-ci.org/oxinabox/Pipe.jl)
+ - Julia 1.0: [![Build Status 0.6](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/2)](https://travis-ci.org/oxinabox/Pipe.jl)
 - Julia Nightly: [![Build Status Nightly](https://travis-matrix-badges.herokuapp.com/repos/oxinabox/Pipe.jl/branches/master/7)](https://travis-ci.org/oxinabox/Pipe.jl)
  
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,39 +1,45 @@
-using Base.Test
 using Pipe
 
+if VERSION >= v"0.7"
+    using Test
+    _macroexpand(x) = macroexpand(Main, x)
+else
+    using Base.Test
+    _macroexpand(x) = macroexpand(x)
+end
 
 #No change to nonpipes functionality 
-@test macroexpand( :(@pipe a) ) == :a #doesn't change single inputs
-@test macroexpand( :(@pipe b(a)) ) == :(b(a)) #doesn't change inputs that a function applications
+@test _macroexpand( :(@pipe a) ) == :a #doesn't change single inputs
+@test _macroexpand( :(@pipe b(a)) ) == :(b(a)) #doesn't change inputs that a function applications
 
-#Compatable with Julia 1.3 piping functionality
-@test macroexpand( :(@pipe a|>b) ) == :(b(a)) #basic
-@test macroexpand( :(@pipe a|>b|>c) ) == :(c(b(a)))  #Keeps chaining 3
-@test macroexpand( :(@pipe a|>b|>c|>d) ) == :(d(c(b(a)))) #Keeps chaining 4
+#Compatable with Julia 0.3 piping functionality
+@test _macroexpand( :(@pipe a|>b) ) == :(b(a)) #basic
+@test _macroexpand( :(@pipe a|>b|>c) ) == :(c(b(a)))  #Keeps chaining 3
+@test _macroexpand( :(@pipe a|>b|>c|>d) ) == :(d(c(b(a)))) #Keeps chaining 4
 
-@test macroexpand( :(@pipe a|>b(x)) ) == :((b(x))(a))  #applying to function calls returning functions
-@test macroexpand( :(@pipe a(x)|>b ) ) == :(b(a(x)))   #feeding functioncall results on wards
+@test _macroexpand( :(@pipe a|>b(x)) ) == :((b(x))(a))  #applying to function calls returning functions
+@test _macroexpand( :(@pipe a(x)|>b ) ) == :(b(a(x)))   #feeding functioncall results on wards
 
-@test macroexpand(:(@pipe 1|>a)) ==:(a(1)) #Works with literals (int)
-@test macroexpand(:(@pipe "foo"|>a)) == :(a("foo")) #Works with literal (string)
-@test macroexpand( :(@pipe a|>bb[2])) == :((bb[2])(a)) #Should work with RHS that is a array reference
+@test _macroexpand(:(@pipe 1|>a)) ==:(a(1)) #Works with literals (int)
+@test _macroexpand(:(@pipe "foo"|>a)) == :(a("foo")) #Works with literal (string)
+@test _macroexpand( :(@pipe a|>bb[2])) == :((bb[2])(a)) #Should work with RHS that is a array reference
 
 
 #Marked locations
-@test macroexpand( :(@pipe a|>b(_) ) ) == :(b(a)) #Marked location only
-@test macroexpand( :(@pipe a|>b(x,_) ) ) == :(b(x,a)) # marked 2nd (and last)
-@test macroexpand( :(@pipe a|>b(_,x) ) ) == :(b(a,x)) # marked first
-@test macroexpand( :(@pipe a|>b(_,_) ) ) == :(b(a,a)) # marked double (Not certain if this is a good idea)
-@test macroexpand( :(@pipe a|>bb[2](x,_))) == :((bb[2])(x,a)) #Should work with RHS that is a array reference
+@test _macroexpand( :(@pipe a|>b(_) ) ) == :(b(a)) #Marked location only
+@test _macroexpand( :(@pipe a|>b(x,_) ) ) == :(b(x,a)) # marked 2nd (and last)
+@test _macroexpand( :(@pipe a|>b(_,x) ) ) == :(b(a,x)) # marked first
+@test _macroexpand( :(@pipe a|>b(_,_) ) ) == :(b(a,a)) # marked double (Not certain if this is a good idea)
+@test _macroexpand( :(@pipe a|>bb[2](x,_))) == :((bb[2])(x,a)) #Should work with RHS that is a array reference
 
 #marked Unpacking
-@test macroexpand( :(@pipe a|>b(_...) ) ) == :(b(a...)) # Unpacking
-@test macroexpand( :(@pipe a|>bb[2](_...))) == :((bb[2])(a...)) #Should work with RHS of arry ref and do unpacking
+@test _macroexpand( :(@pipe a|>b(_...) ) ) == :(b(a...)) # Unpacking
+@test _macroexpand( :(@pipe a|>bb[2](_...))) == :((bb[2])(a...)) #Should work with RHS of arry ref and do unpacking
 
 #Mixing modes
-@test macroexpand( :(@pipe a|>b|>c(_) ) ) == :(c(b(a)))
-@test macroexpand( :(@pipe a|>b(x,_)|>c|>d(_,y) ) ) == :(d(c(b(x,a)),y))
-@test macroexpand( :(@pipe a|>b(xb,_)|>c|>d(_,xd)|>e(xe) |>f(xf,_,yf) ) ) == :(f(xf,(e(xe))(d(c(b(xb,a)),xd)),yf)) #Very Complex
+@test _macroexpand( :(@pipe a|>b|>c(_) ) ) == :(c(b(a)))
+@test _macroexpand( :(@pipe a|>b(x,_)|>c|>d(_,y) ) ) == :(d(c(b(x,a)),y))
+@test _macroexpand( :(@pipe a|>b(xb,_)|>c|>d(_,xd)|>e(xe) |>f(xf,_,yf) ) ) == :(f(xf,(e(xe))(d(c(b(xb,a)),xd)),yf)) #Very Complex
 
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,7 @@
 using Pipe
 
-if VERSION >= v"0.7"
-    using Test
-    _macroexpand(x) = macroexpand(Main, x)
-else
-    using Base.Test
-    _macroexpand(x) = macroexpand(x)
-end
+using Test
+_macroexpand(x) = macroexpand(Main, x)
 
 #No change to nonpipes functionality 
 @test _macroexpand( :(@pipe a) ) == :a #doesn't change single inputs


### PR DESCRIPTION
I've tested this on 0.3, 0.4, 0.5, 0.6 and 0.7

Seems all good