### PR TITLE
Added support for replacing args in other expressions than calls

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 1.0
+julia 0.7

--- a/src/Pipe.jl
+++ b/src/Pipe.jl
@@ -22,23 +22,21 @@ function rewrite(ff::Expr,target)
         rep
     end
 
-    if (ff.head in [:call, :ref])
-        rep_args = map(replace,ff.args)
-        if ff.args != rep_args
-            #_ subsitution
-            ff.args=rep_args
-            return ff
-        end
+    rep_args = map(replace,ff.args)
+    if ff.args != rep_args
+        #_ subsitution
+        ff.args=rep_args
+        return ff
     end
-    #No subsitution was done (either cos not a call, or cos no _ found)
-    #Apply to a function that is being returned by ff, (ff could be a function call or something more complex)
+    #No subsitution was done (no _ found)
+    #Apply to a function that is being returned by ff,
+    #(ff could be a function call or something more complex)
     rewrite_apply(ff,target)
 end
 
 
 function rewrite_apply(ff, target)
-    #function application
-    :($ff($target))
+    :($ff($target)) #function application
 end
 
 function rewrite(ff::Symbol, target)
@@ -50,8 +48,7 @@ function rewrite(ff::Symbol, target)
 end
 
 function funnel(ee::Any) #Could be a Symbol could be a literal
-    #first (left most) input
-    ee
+    ee #first (left most) input
 end
 
 function funnel(ee::Expr)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,7 @@ using Test
 _macroexpand(x) = macroexpand(Main, x)
 
 
-#No change to nonpipes functionality 
+#No change to nonpipes functionality
 @test _macroexpand( :(@pipe a) ) == :a #doesn't change single inputs
 @test _macroexpand( :(@pipe b(a)) ) == :(b(a)) #doesn't change inputs that a function applications
 
@@ -18,6 +18,7 @@ _macroexpand(x) = macroexpand(Main, x)
 @test _macroexpand(:(@pipe 1|>a)) ==:(a(1)) #Works with literals (int)
 @test _macroexpand(:(@pipe "foo"|>a)) == :(a("foo")) #Works with literal (string)
 @test _macroexpand( :(@pipe a|>bb[2])) == :((bb[2])(a)) #Should work with RHS that is a array reference
+
 
 
 #Marked locations

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,5 @@
 using Pipe
 using Test
-_macroexpand(x) = macroexpand(Main, x)
 
 _macroexpand(q) = macroexpand(Main, q)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -28,6 +28,14 @@ _macroexpand(x) = macroexpand(Main, x)
 @test _macroexpand( :(@pipe a|>b(_,_) ) ) == :(b(a,a)) # marked double (Not certain if this is a good idea)
 @test _macroexpand( :(@pipe a|>bb[2](x,_))) == :((bb[2])(x,a)) #Should work with RHS that is a array reference
 
+#Macros and blocks
+macro testmacro(arg, n)
+    esc(:($arg + $n))
+end
+@test macroexpand( :(@pipe a |> @testmacro _ 3 ) ) == :(a + 3) # Can pipe into macros
+@test macroexpand( :(@pipe a |> begin b = _; c + b + _ end )) == :(
+                                begin b = a; c + b + a end)
+
 #marked Unpacking
 @test _macroexpand( :(@pipe a|>b(_...) ) ) == :(b(a...)) # Unpacking
 @test _macroexpand( :(@pipe a|>bb[2](_...))) == :((bb[2])(a...)) #Should work with RHS of arry ref and do unpacking


### PR DESCRIPTION
Obvious from added tests:
```julia
@test macroexpand( :(@pipe a |> _)) == :(a) #Identity works
@test macroexpand( :(@pipe a |> _[b])) == :(a[b]) #Indexing works
```
Which means this works:
```julia
@pipe 42 |> _ # produces 42
@pipe ["first", "last"] |> _[2] # produces "last"
```